### PR TITLE
fix(game12-cat): Prevent cat hat from being destroyed

### DIFF
--- a/src/scenes/game12-cat.js
+++ b/src/scenes/game12-cat.js
@@ -255,7 +255,6 @@ export default class Game extends Phaser.Scene {
 
                             if (this.cat.y < -this.cat.displayHeight) {
                               if (this.cat.active) this.cat.destroy();
-                              if (this.catHat.active) this.catHat.destroy();
                               return;
                             }
 


### PR DESCRIPTION
This change updates the 'fly away' sequence to no longer destroy the cat's hat when the cat flies off-screen. The hat will now remain in the scene.