### PR TITLE
Fix: Correctly detect parabomb collision with the ground

### DIFF
--- a/src/sprites/parabomb.js
+++ b/src/sprites/parabomb.js
@@ -98,7 +98,7 @@ export default class Parabomb extends Phaser.Physics.Arcade.Sprite {
             return;
         }
 
-        if ( this.body.blocked.down && this.anims.getCurrentKey() === 'fall' ) {
+        if ( this.body.blocked.down && this.anims.currentAnim.key === 'fall' ) {
             this.setOffset( -19, -16 );
             this.setGravityY( 800 );
             this.on('animationcomplete', (anim, frame) => this.emit('animationcomplete_' + anim.key, anim, frame));


### PR DESCRIPTION
The parabomb was not correctly detecting collision with the bottom of the screen. This was because it was using `this.body.checkWorldBounds()`, which does not return a boolean value indicating collision. This has been fixed by using `this.body.blocked.down`, which accurately detects when the sprite collides with the bottom of the world.

This also fixes a subsequent `TypeError: this.anims.getCurrentKey is not a function` by replacing the incorrect method call with `this.anims.currentAnim.key`.