### PR TITLE
Build M's inner V from flipped brick-particle sprites for legibility

### DIFF
--- a/src/scenes/game21-goofy.js
+++ b/src/scenes/game21-goofy.js
@@ -41,7 +41,7 @@ const LETTER_PATTERNS = {
   'A': ['.X.', 'X.X', 'XXX', 'X.X', 'X.X'],
   'P': ['XX.', 'X.X', 'XX.', 'X..', 'X..'],
   'Y': ['X.X', 'X.X', '.X.', '.X.', '.X.'],
-  'M': ['X.X', 'XXX', 'XXX', 'X.X', 'X.X'],
+  'M': ['X.X', 'X.X', 'X.X', 'X.X', 'X.X'],
   'O': ['XXX', 'X.X', 'X.X', 'X.X', 'XXX'],
   'T': ['XXX', '.X.', '.X.', '.X.', '.X.'],
   'E': ['XXX', 'X..', 'XX.', 'X..', 'XXX'],
@@ -213,6 +213,41 @@ export default class Game21Goofy extends Phaser.Scene {
           consumed: false
         });
       }
+    }
+
+    if (char === 'M') {
+      this.addMDiagonals(container, containerX, containerY, cosR, sinR);
+    }
+  }
+
+  addMDiagonals(container, containerX, containerY, cosR, sinR) {
+    const particleScale = LETTER_CELL_SIZE / 8;
+    const diagonals = [
+      { localX: -2.2, localY: -5.5, flipX: false },
+      { localX: -1.0, localY: -2.5, flipX: false },
+      { localX:  0.0, localY: -0.5, flipX: false },
+      { localX:  1.0, localY: -2.5, flipX: true  },
+      { localX:  2.2, localY: -5.5, flipX: true  }
+    ];
+
+    for (const d of diagonals) {
+      const p = this.add.image(d.localX, d.localY, BRICK_PARTICLE_KEY, 'atlas_s0');
+      p.setScale(particleScale);
+      if (d.flipX) {
+        p.setFlipX(true);
+      }
+      container.add(p);
+
+      const worldX = containerX + d.localX * cosR - d.localY * sinR;
+      const worldY = containerY + d.localX * sinR + d.localY * cosR;
+      this.collidables.push({
+        type: 'brick',
+        worldX,
+        worldY,
+        sprite: p,
+        container,
+        consumed: false
+      });
     }
   }
 


### PR DESCRIPTION
The previous 3x3-block M pattern filled the middle column on rows one and two, which read as a chunky H rather than M. Reduce M to its two pillars (col 0 and col 2) and overlay five mario-brick-particle sprites along the inner V: three on the left arm descending toward center, two mirrored on the right with setFlipX so the angled chunk faces the correct direction. The particles are tracked as brick-type collidables so they shatter with the rest of the letter when Goofy jumps into them.