### PR TITLE
game20: bounce monkey away during last 3 frames of envy kick

### DIFF
--- a/src/scenes/game20-envy.js
+++ b/src/scenes/game20-envy.js
@@ -31,7 +31,7 @@ const KICK_REACH_PX = 6;
 
 const MONKEY_BODY_WIDTH_FRACTION = 0.45;
 
-const KICK_FINAL_FRAME = 'atlas_s7';
+const KICK_LAUNCH_FRAME = 'atlas_s5';
 
 const HAPTIC_KICK_MS = 40;
 const HAPTIC_FINISHER_PATTERN = [80, 40, 160];
@@ -347,7 +347,7 @@ export default class Game extends Phaser.Scene {
     this.envy.anims.timeScale = this.currentKickFrameRate() / KICK_INITIAL_FRAMERATE;
 
     const onUpdate = (anim, frame) => {
-      if (!frame || frame.textureFrame !== KICK_FINAL_FRAME) {
+      if (!frame || frame.textureFrame !== KICK_LAUNCH_FRAME) {
         return;
       }
       this.envy.off(Phaser.Animations.Events.ANIMATION_UPDATE, onUpdate);


### PR DESCRIPTION
## Summary
- In `?scene=20`, the envy-kick animation has 8 frames (`atlas_s0`–`atlas_s7`). The launch was being triggered on the very last frame (`atlas_s7`), so the kick visually "ended" the instant the monkey started flying away — there was no animation time left for the bounce to read on screen.
- Move the launch trigger to `atlas_s5`, so the monkey's bounce away from envy plays out across the **last 3 frames** of the attack (`atlas_s5`, `atlas_s6`, `atlas_s7`).
- Renamed `KICK_FINAL_FRAME` → `KICK_LAUNCH_FRAME` since the constant no longer points at the final frame.

## Test plan
- [ ] Load `?scene=20`, let envy approach and connect a kick — confirm the monkey is visibly flying away while the kick animation finishes (frames 5–7), instead of launching only on the last frame.
- [ ] Confirm the finisher sequence still triggers correctly when the kill kick lands (finisher impact frame is unchanged at `atlas_s5`).
- [ ] Confirm camera shake, blood splat, haptic pulse, and HP decrement all still fire on kick contact.

https://claude.ai/code/session_01AuRtWCTDcRTPFxntzShZqc

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuRtWCTDcRTPFxntzShZqc)_