### PR TITLE
game20: always bounce monkey on kick, 2x velocity for last 5 frames

### DIFF
--- a/src/scenes/game20-envy.js
+++ b/src/scenes/game20-envy.js
@@ -31,7 +31,8 @@ const KICK_REACH_PX = 6;
 
 const MONKEY_BODY_WIDTH_FRACTION = 0.45;
 
-const KICK_LAUNCH_FRAME = 'atlas_s5';
+const KICK_BOOST_FRAME = 'atlas_s3';
+const KICK_BOOST_MULTIPLIER = 2;
 
 const HAPTIC_KICK_MS = 40;
 const HAPTIC_FINISHER_PATTERN = [80, 40, 160];
@@ -346,15 +347,21 @@ export default class Game extends Phaser.Scene {
 
     this.envy.anims.timeScale = this.currentKickFrameRate() / KICK_INITIAL_FRAMERATE;
 
-    const onUpdate = (anim, frame) => {
-      if (!frame || frame.textureFrame !== KICK_LAUNCH_FRAME) {
+    this.launchMonkey(launchDir, vx, vy);
+    this.triggerHaptic(HAPTIC_KICK_MS);
+
+    const onBoost = (anim, frame) => {
+      if (!frame || frame.textureFrame !== KICK_BOOST_FRAME) {
         return;
       }
-      this.envy.off(Phaser.Animations.Events.ANIMATION_UPDATE, onUpdate);
-      this.launchMonkey(launchDir, vx, vy);
-      this.triggerHaptic(HAPTIC_KICK_MS);
+      this.envy.off(Phaser.Animations.Events.ANIMATION_UPDATE, onBoost);
+      this.launchMonkey(
+        launchDir,
+        vx * KICK_BOOST_MULTIPLIER,
+        vy * KICK_BOOST_MULTIPLIER
+      );
     };
-    this.envy.on(Phaser.Animations.Events.ANIMATION_UPDATE, onUpdate);
+    this.envy.on(Phaser.Animations.Events.ANIMATION_UPDATE, onBoost);
 
     this.envy.play(ENVY_KICK_ANIM);
 


### PR DESCRIPTION
## Summary
- Monkey is now launched the moment the kick connects, so it **always** bounces away on contact instead of waiting for a specific animation frame.
- When the kick animation reaches `atlas_s3` (the start of the last 5 frames of the 8-frame kick), the launch velocity is reapplied at **2x**, giving a visible secondary boost as the kick follows through.

## Test plan
- [ ] Load `?scene=20`. Envy approaches and connects a kick — confirm the monkey starts flying away immediately on contact.
- [ ] Mid-kick, confirm a noticeable second push during the last 5 frames (monkey velocity visibly increases).
- [ ] Confirm finisher kick still kills the monkey on the kill blow (the finisher's own impact handling at `atlas_s5` is untouched).
- [ ] Confirm camera shake, blood splat, haptic pulse, and HP decrement still fire correctly.

https://claude.ai/code/session_01AuRtWCTDcRTPFxntzShZqc

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuRtWCTDcRTPFxntzShZqc)_